### PR TITLE
feat build: add CMake install targets and Conan 2.x recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,10 @@ add_library(userver::cassandra ALIAS ${CASSANDRA_ROOT_PROJECT_NAME})
 target_link_libraries(${CASSANDRA_ROOT_PROJECT_NAME} PUBLIC userver::core lz4)
 
 target_include_directories(
-  ${CASSANDRA_ROOT_PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                                        $<INSTALL_INTERFACE:include>
+  ${CASSANDRA_ROOT_PROJECT_NAME}
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
-include_directories(src)
 
 # Install
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,26 +17,56 @@ find_package(
 file(GLOB_RECURSE SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
 list(FILTER SOURCES EXCLUDE REGEX ".*(_test|_benchmark)\\.cpp$")
 
-add_library(
-  ${CASSANDRA_ROOT_PROJECT_NAME} STATIC ${SOURCES})
+add_library(${CASSANDRA_ROOT_PROJECT_NAME} STATIC ${SOURCES})
 
 add_library(userver::cassandra ALIAS ${CASSANDRA_ROOT_PROJECT_NAME})
 
 target_link_libraries(${CASSANDRA_ROOT_PROJECT_NAME} PUBLIC userver::core lz4)
 
-target_include_directories(${CASSANDRA_ROOT_PROJECT_NAME}
-                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(
+  ${CASSANDRA_ROOT_PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                        $<INSTALL_INTERFACE:include>
+)
 include_directories(src)
+
+# Install
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+install(
+  TARGETS ${CASSANDRA_ROOT_PROJECT_NAME}
+  EXPORT ${CASSANDRA_ROOT_PROJECT_NAME}-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(
+  EXPORT ${CASSANDRA_ROOT_PROJECT_NAME}-targets
+  FILE ${CASSANDRA_ROOT_PROJECT_NAME}Targets.cmake
+  NAMESPACE userver::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CASSANDRA_ROOT_PROJECT_NAME}
+)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${CASSANDRA_ROOT_PROJECT_NAME}Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${CASSANDRA_ROOT_PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CASSANDRA_ROOT_PROJECT_NAME}
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CASSANDRA_ROOT_PROJECT_NAME}Config.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CASSANDRA_ROOT_PROJECT_NAME}
+)
+
 option(CASSANDRA_BUILD_SAMPLES "Build userver samples" OFF)
 option(CASSANDRA_BUILD_TESTS "Build userver tests" ON)
 
 if(CASSANDRA_BUILD_SAMPLES)
-    add_subdirectory(samples/example_service)
+  add_subdirectory(samples/example_service)
 endif()
 
-
 if(CASSANDRA_BUILD_TESTS)
-    enable_testing()
-    add_subdirectory(unittests)
-    add_subdirectory(benchmarks)
+  enable_testing()
+  add_subdirectory(unittests)
+  add_subdirectory(benchmarks)
 endif()

--- a/cmake/userver-cql-driverConfig.cmake.in
+++ b/cmake/userver-cql-driverConfig.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(userver COMPONENTS core)
+find_dependency(lz4)
+
+include("${CMAKE_CURRENT_LIST_DIR}/userver-cql-driverTargets.cmake")
+
+check_required_components(userver-cql-driver)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,61 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import get
+
+
+class UServerCqlDriverConan(ConanFile):
+    name = "userver-cql-driver"
+    description = "CQL (Cassandra Query Language) driver for userver framework"
+    license = "Apache-2.0"
+    topics = ("userver", "cassandra", "cql", "driver")
+
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    exports_sources = ["CMakeLists.txt", "src/*", "include/*", "cmake/*"]
+
+    def requirements(self):
+        self.requires("userver/[^2.15]")
+        self.requires("lz4/[>=1.9]")
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def source(self):
+        if not os.path.exists(
+            os.path.join(self.source_folder, "CMakeLists.txt")
+        ):
+            get(
+                self,
+                **self.conan_data["sources"][self.version],
+                strip_root=True,
+            )
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["CASSANDRA_BUILD_SAMPLES"] = False
+        tc.variables["CASSANDRA_BUILD_TESTS"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "userver-cql-driver")
+        self.cpp_info.set_property("cmake_target_name", "userver::cassandra")
+        self.cpp_info.libs = ["userver-cql-driver"]


### PR DESCRIPTION
### Overview

This PR introduces proper CMake install targets and a Conan 2.x recipe for `userver-cql-driver`, enabling the library to be consumed both as a local dependency within a monorepo and as a versioned package from a private Conan registry.

### Changes

**`CMakeLists.txt`**
- Switched `target_include_directories` to use generator expressions (`$<BUILD_INTERFACE:...>` / `$<INSTALL_INTERFACE:...>`) to correctly expose headers in both build-tree and install-tree contexts
- Added `GNUInstallDirs`-based install rules for the static archive, public headers, and CMake export targets
- Added `configure_package_config_file` to generate a relocatable `userver-cql-driverConfig.cmake` that correctly propagates transitive dependencies (`userver::core`, `lz4`) to downstream consumers
- Added `cmake/userver-cql-driverConfig.cmake.in` template

**`conanfile.py`**
- Recipe supports dual-mode operation: `conan create .` from the repository root uses `exports_sources`, while installation from a remote registry downloads the source archive via `conandata.yml`
- `package()` delegates entirely to `cmake.install()`, keeping packaging logic DRY and consistent with the CMake install targets
- Declared `userver/[^2.15]` and `lz4/[>=1.9]` as Conan requirements, matching existing monorepo conventions

### Testing

```bash
conan create . --version=0.1.0 --build=missing
```

### Notes

- `CASSANDRA_BUILD_TESTS` and `CASSANDRA_BUILD_SAMPLES` are disabled during Conan packaging to avoid pulling in test infrastructure