### PR TITLE
feat: make result set thinner

### DIFF
--- a/include/cassandra/detail/result_wrapper.hpp
+++ b/include/cassandra/detail/result_wrapper.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+
+#include <cassandra/io/protocol/types.hpp>
+#include <cassandra/cassandra_fwd.hpp>
+
+namespace cassandra::detail {
+class ResultWrapper {
+public:
+    ResultWrapper(
+        std::vector<io::protocol::BytesBuffer>&& rows_content,
+        io::Int columns_count,
+        io::Int rows_count
+    )
+        : _rows_content(std::move(rows_content)),
+          _columns_count(columns_count),
+          _rows_count(rows_count) {}
+
+    bool Empty() const { return _rows_content.empty(); }
+
+    auto RowsAffected() const { return _rows_count; }
+
+    auto ColumnsAffected() const { return _columns_count; }
+
+    std::span<const io::protocol::BytesBuffer> RowsContentView() const {
+        return _rows_content;
+    }
+
+private:
+    std::vector<io::protocol::BytesBuffer> _rows_content;
+
+    io::Int _columns_count;
+    io::Int _rows_count;
+};
+}  // namespace detail

--- a/include/cassandra/io/buffer_io_base.hpp
+++ b/include/cassandra/io/buffer_io_base.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <boost/endian/conversion.hpp>
+#include <cassandra/io/cassandra_types.hpp>
 #include <cassandra/io/protocol/types.hpp>
 #include <cstddef>
 #include <cstring>
 #include <stdexcept>
 #include <type_traits>
 #include <userver/utils/void_t.hpp>
-#include "cassandra/io/cassandra_types.hpp"
 
 namespace cassandra::io::detail {
 template <typename T>

--- a/include/cassandra/result_set.hpp
+++ b/include/cassandra/result_set.hpp
@@ -5,27 +5,17 @@
 #include <cassandra/io/row_types.hpp>
 #include <cassandra/row.hpp>
 #include <userver/logging/log.hpp>
-#include <vector>
-
+#include <cassandra/detail/result_wrapper.hpp>
 namespace cassandra {
 class ResultSet {
 public:
-    bool Empty() const { return _rows_content.empty(); }
+    bool Empty() const { return !_pimpl || _pimpl->Empty(); }
 
-    auto RowsAffected() const { return _columns_count; }
+    auto RowsAffected() const { return _pimpl->RowsAffected(); }
 
-    auto ColumnsAffected() const { return _rows_count; }
+    auto ColumnsAffected() const { return _pimpl->ColumnsAffected(); }
 
-    ResultSet() : _rows_content({}), _columns_count(0), _rows_count(0){};
-
-    ResultSet(
-        std::vector<io::protocol::BytesBuffer>&& rows,
-        io::Int columns_count,
-        io::Int rows_count
-    )
-        : _rows_content(rows),
-          _columns_count(columns_count),
-          _rows_count(rows_count) {}
+    ResultSet(std::shared_ptr<detail::ResultWrapper> pimpl) : _pimpl(pimpl) {}
 
     template <class T>
     T AsSingleRow(io::FieldTag tag) const {
@@ -39,21 +29,22 @@ public:
 
     template <class Container>
     Container AsContainer(io::RowTag tag) const {
+        auto content = _pimpl->RowsContentView();
         using ElementType = typename Container::value_type;
         Container result;
-        result.reserve(_rows_content.size());
-        for (const auto& row : _rows_content) {
-            result.push_back(Row(row, _columns_count).As<ElementType>(tag));
+        result.reserve(content.size());
+        for (const auto& row : content) {
+            result.push_back(Row(row, _pimpl->ColumnsAffected()).As<ElementType>(tag)
+            );
         }
         return result;
     }
 
-    Row Front() const { return Row(_rows_content.front(), _columns_count); }
+    Row Front() const {
+        return Row(_pimpl->RowsContentView().front(), _pimpl->ColumnsAffected());
+    }
 
 private:
-    std::vector<io::protocol::BytesBuffer> _rows_content;
-
-    io::Int _columns_count;
-    io::Int _rows_count;
+    std::shared_ptr<detail::ResultWrapper> _pimpl;
 };
 }  // namespace cassandra

--- a/include/cassandra/row.hpp
+++ b/include/cassandra/row.hpp
@@ -8,15 +8,14 @@
 #include <type_traits>
 #include <userver/compiler/demangle.hpp>
 #include <userver/logging/log.hpp>
-#include <vector>
 
 namespace cassandra {
+    
+// make sure that the buffer is valid for the lifetime of the Row object
 class Row {
 public:
-    Row(io::protocol::BytesBuffer&& buffer, int columns_count)
+    Row(io::protocol::BytesBufferView buffer, int columns_count)
         : _row_content(std::move(buffer)), _columns_count(columns_count) {}
-    Row(const io::protocol::BytesBuffer& buffer, int columns_count)
-        : _row_content(buffer), _columns_count(columns_count) {}
 
     io::protocol::BytesBufferView GetBufferView() const { return _row_content; }
 
@@ -41,7 +40,7 @@ public:
     size_t Size() const { return _columns_count; }
 
 private:
-    std::vector<io::Bytes> _row_content;
+    io::protocol::BytesBufferView _row_content;
     int _columns_count;
 
     template <typename T>

--- a/samples/example_service/main.cpp
+++ b/samples/example_service/main.cpp
@@ -103,6 +103,7 @@ const ::cassandra::Query kInsertQuery{
     "insert into benchmark_ks.my_table (id, name) values (?, ?)"
 };
 const ::cassandra::Query kSelectQuery{"select id, name from benchmark_ks.my_table"};
+const ::cassandra::Query kSelectByIdQuery{"select id, name from benchmark_ks.my_table where id = ? ALLOW FILTERING"};
 
 const ::cassandra::Query kSelectLimitQuery{
     "select id, name from benchmark_ks.my_table LIMIT ?"
@@ -141,7 +142,7 @@ userver::formats::json::Value Cassandra::HandleRequestJsonThrow(
         );
 
         auto select_result =
-            _session_ptr->Execute(cassandra::Consistency::kLocalOne, kSelectQuery);
+            _session_ptr->Execute(cassandra::Consistency::kLocalOne, kSelectByIdQuery, id);
         if (!select_result.RowsAffected()) {
             request.SetResponseStatus(userver::server::http::HttpStatus::NotFound);
             return {};

--- a/src/io/protocol/response_message.hpp
+++ b/src/io/protocol/response_message.hpp
@@ -6,9 +6,10 @@
 #include <cassandra/io/protocol/lz4_utils.hpp>
 #include <cassandra/io/protocol/message.hpp>
 #include <cassandra/io/protocol/types.hpp>
-#include <cassandra/result_set.hpp>
 #include <io/protocol/column_option.hpp>
 #include <io/protocol/events/schema_change.hpp>
+#include <memory>
+#include <cassandra/result_set.hpp>
 #include <userver/logging/log.hpp>
 #include <utility>
 #include <variant>
@@ -235,16 +236,16 @@ public:
     ResultSet GetResultSet() {
         if (_kind != ResultKind::kRows) {
             LOG_DEBUG("return empty result set");
-            return {};
+            return ResultSet{nullptr};
         }
         auto& row_kind = std::get<RowKind>(_payload);
         LOG_DEBUG("GET ROW KIND");
         LOG_DEBUG("RETURN RESULT SET");
-        return ResultSet{
+        return ResultSet{std::make_shared<cassandra::detail::ResultWrapper>(
             std::move(row_kind.rows_content),
             row_kind.columns_count,
             row_kind.rows_count
-        };
+        )};
     }
 
     io::ShortBytes GetPreparedStatementId() {


### PR DESCRIPTION
In previous implementations `ResultSet` handles all of response data such as: rows content, columns/rows count. Now it will contains shared pointer on `ResultWrapper`, which will be contains previously described fields. I am confident that this approach will lead to a reduction in allocated memory and an increase in performance in user applications.