### PR TITLE
feat: add helth check periodic task for connection pool

### DIFF
--- a/include/cassandra/detail/result_wrapper.hpp
+++ b/include/cassandra/detail/result_wrapper.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-
-#include <cassandra/io/protocol/types.hpp>
 #include <cassandra/cassandra_fwd.hpp>
+#include <cassandra/io/protocol/types.hpp>
 
 namespace cassandra::detail {
 class ResultWrapper {
@@ -32,4 +31,4 @@ private:
     io::Int _columns_count;
     io::Int _rows_count;
 };
-}  // namespace detail
+}  // namespace cassandra::detail

--- a/include/cassandra/exception.hpp
+++ b/include/cassandra/exception.hpp
@@ -3,7 +3,7 @@
 #include <fmt/core.h>
 #include <stdexcept>
 #include <string_view>
-#include "cassandra/io/protocol/types.hpp"
+#include <cassandra/io/protocol/types.hpp>
 namespace cassandra::exceptions {
 class Error : public std::runtime_error {
     using runtime_error::runtime_error;

--- a/include/cassandra/exception.hpp
+++ b/include/cassandra/exception.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <cassandra/io/protocol/types.hpp>
 #include <stdexcept>
 #include <string_view>
-#include <cassandra/io/protocol/types.hpp>
 namespace cassandra::exceptions {
 class Error : public std::runtime_error {
     using runtime_error::runtime_error;

--- a/include/cassandra/result_set.hpp
+++ b/include/cassandra/result_set.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <cassandra/detail/result_wrapper.hpp>
 #include <cassandra/io/buffer_reader.hpp>
 #include <cassandra/io/protocol/types.hpp>
 #include <cassandra/io/row_types.hpp>
 #include <cassandra/row.hpp>
 #include <userver/logging/log.hpp>
-#include <cassandra/detail/result_wrapper.hpp>
 namespace cassandra {
 class ResultSet {
 public:

--- a/include/cassandra/row.hpp
+++ b/include/cassandra/row.hpp
@@ -10,7 +10,7 @@
 #include <userver/logging/log.hpp>
 
 namespace cassandra {
-    
+
 // make sure that the buffer is valid for the lifetime of the Row object
 class Row {
 public:

--- a/samples/example_service/configs/config_vars.yaml
+++ b/samples/example_service/configs/config_vars.yaml
@@ -1,6 +1,8 @@
 worker-threads: 4
 worker-fs-threads: 2
-logger-level: debug
+worker-monitor-threads: 2
+event-threads: 2
+logger-level: warning
 
 is-testing: false
 

--- a/samples/example_service/configs/static_config.yaml
+++ b/samples/example_service/configs/static_config.yaml
@@ -1,10 +1,18 @@
 components_manager:
+    event_thread_pool: # ev pools to deal with OS events
+        threads: $event-threads
+        threads#fallback: 2
     task_processors: # Task processor is an executor for coroutine tasks
         main-task-processor: # Make a task processor for CPU-bound coroutine tasks.
             worker_threads: $worker-threads # Process tasks in 4 threads.
 
         fs-task-processor: # Make a separate task processor for filesystem bound tasks.
             worker_threads: $worker-fs-threads
+
+        monitor-task-processor: # for monitoring
+            thread_name: mon-worker
+            worker_threads: $worker-monitor-threads
+            worker_threads#fallback: 1
 
     default_task_processor: main-task-processor
 
@@ -13,6 +21,14 @@ components_manager:
             listener: # configuring the main listening socket...
                 port: $server-port # ...to listen on this port and...
                 task_processor: main-task-processor # ...process incoming requests on this task processor.
+            listener-monitor:
+                # Listen on localhost:8085 for developer/utility requests
+                port: $monitor-server-port
+                port#fallback: 8086
+                connection:
+                    in_buffer_size: 32768
+                    requests_queue_size_threshold: 100
+                task_processor: monitor-task-processor
 
         logging:
             fs-task-processor: fs-task-processor
@@ -69,3 +85,9 @@ components_manager:
 
         cassandra-component:
             keyspace: $cassandra-keyspace
+
+        handler-log-level:
+            path: /service/log-level/{level}
+            method: GET,PUT
+            task_processor: monitor-task-processor
+

--- a/samples/example_service/main.cpp
+++ b/samples/example_service/main.cpp
@@ -9,6 +9,7 @@
 #include <userver/formats/serialize/common_containers.hpp>
 #include <userver/formats/serialize/to.hpp>
 #include <userver/logging/log.hpp>
+#include <userver/server/handlers/log_level.hpp>
 #include <userver/server/handlers/ping.hpp>
 #include <userver/server/handlers/tests_control.hpp>
 #include <userver/storages/secdist/component.hpp>
@@ -82,6 +83,7 @@ int main(int argc, char* argv[]) {
                               .Append<userver::server::handlers::TestsControl>()
                               .Append<userver::congestion_control::Component>()
                               .Append<components::Cassandra>("cassandra-component")
+                              .Append<userver::server::handlers::LogLevel>()
                               .Append<views::Cassandra>()
                               .Append<views::CassandraBatch>();
 

--- a/samples/example_service/main.cpp
+++ b/samples/example_service/main.cpp
@@ -103,7 +103,9 @@ const ::cassandra::Query kInsertQuery{
     "insert into benchmark_ks.my_table (id, name) values (?, ?)"
 };
 const ::cassandra::Query kSelectQuery{"select id, name from benchmark_ks.my_table"};
-const ::cassandra::Query kSelectByIdQuery{"select id, name from benchmark_ks.my_table where id = ? ALLOW FILTERING"};
+const ::cassandra::Query kSelectByIdQuery{
+    "select id, name from benchmark_ks.my_table where id = ? ALLOW FILTERING"
+};
 
 const ::cassandra::Query kSelectLimitQuery{
     "select id, name from benchmark_ks.my_table LIMIT ?"
@@ -141,8 +143,9 @@ userver::formats::json::Value Cassandra::HandleRequestJsonThrow(
             cassandra::Consistency::kLocalOne, kInsertQuery, id, name
         );
 
-        auto select_result =
-            _session_ptr->Execute(cassandra::Consistency::kLocalOne, kSelectByIdQuery, id);
+        auto select_result = _session_ptr->Execute(
+            cassandra::Consistency::kLocalOne, kSelectByIdQuery, id
+        );
         if (!select_result.RowsAffected()) {
             request.SetResponseStatus(userver::server::http::HttpStatus::NotFound);
             return {};

--- a/src/detail/connection.cpp
+++ b/src/detail/connection.cpp
@@ -163,7 +163,5 @@ ResultSet Connection::BatchExecute(
     return _pimpl->BatchExecute(level, std::move(store), statement_cmd_ctl);
 }
 
-void Connection::Close(){
-    _pimpl->Close().Wait();
-}
+void Connection::Close() { _pimpl->Close().Wait(); }
 }  // namespace cassandra::detail

--- a/src/detail/connection.cpp
+++ b/src/detail/connection.cpp
@@ -162,4 +162,8 @@ ResultSet Connection::BatchExecute(
 ) {
     return _pimpl->BatchExecute(level, std::move(store), statement_cmd_ctl);
 }
+
+void Connection::Close(){
+    _pimpl->Close().Wait();
+}
 }  // namespace cassandra::detail

--- a/src/detail/connection.hpp
+++ b/src/detail/connection.hpp
@@ -35,6 +35,8 @@ public:
 
     bool IsBroken() const;
 
+    void Close();
+
     ResultSet Execute(
         Consistency level,
         const Query& query,

--- a/src/detail/connection_impl.cpp
+++ b/src/detail/connection_impl.cpp
@@ -175,6 +175,7 @@ std::shared_ptr<io::protocol::ResponseMessage> ConnectionImpl::ExecuteMessageAsy
     std::unique_ptr<io::protocol::RequestMessage> message,
     userver::engine::Deadline deadline
 ) {
+    using Duration = decltype(deadline.TimeLeft());
     LOG_DEBUG("ASYNC EXECUTE");
     StreamGuard guard(_stream_pool);
     message->SetStreamId(guard.GetStreamId());
@@ -182,8 +183,10 @@ std::shared_ptr<io::protocol::ResponseMessage> ConnectionImpl::ExecuteMessageAsy
     SendMessage(std::move(message), deadline);
     std::shared_ptr<io::protocol::ResponseMessage> result;
     while (!_received_message_consumer_map[guard.GetStreamId()].PopNoblock(result)) {
-        // MarkBroken();
-        // throw std::runtime_error("Timeout");
+        if(deadline.TimeLeft() == Duration::zero()) {
+            MarkBroken();
+            throw exceptions::ConnectionError("Timeout");
+        }
     }
 
     CheckError(result);

--- a/src/detail/connection_impl.cpp
+++ b/src/detail/connection_impl.cpp
@@ -142,7 +142,7 @@ ConnectionImpl::ConnectionImpl(
     _received_message_consumer_map.reserve(StreamPool::kMaxStreams);
 
     for (size_t i = 0; i < StreamPool::kMaxStreams; ++i) {
-        _received_message_queue_map.emplace_back(RecvMessageQueue::Create(10));
+        _received_message_queue_map.emplace_back(RecvMessageQueue::Create(1));
         auto back = _received_message_queue_map.back();
         _received_message_producer_map.emplace_back(back->GetProducer());
         _received_message_consumer_map.emplace_back(back->GetConsumer());
@@ -180,10 +180,15 @@ std::shared_ptr<io::protocol::ResponseMessage> ConnectionImpl::ExecuteMessageAsy
     StreamGuard guard(_stream_pool);
     message->SetStreamId(guard.GetStreamId());
 
-    SendMessage(std::move(message), deadline);
+    auto task = userver::engine::CriticalAsyncNoSpan(
+        bg_task_processor_,
+        [this, request = std::move(message), deadline]() mutable {
+            SendMessage(std::move(request), deadline);
+        }
+    );
     std::shared_ptr<io::protocol::ResponseMessage> result;
     while (!_received_message_consumer_map[guard.GetStreamId()].PopNoblock(result)) {
-        if(deadline.TimeLeft() == Duration::zero()) {
+        if (deadline.TimeLeft() == Duration::zero()) {
             MarkBroken();
             throw exceptions::ConnectionError("Timeout");
         }

--- a/src/detail/connection_impl.hpp
+++ b/src/detail/connection_impl.hpp
@@ -72,6 +72,7 @@ public:
 
     ~ConnectionImpl();
 
+    userver::engine::Task Close();
 private:
     userver::engine::io::Socket _socket;
     userver::engine::TaskProcessor& bg_task_processor_;
@@ -116,7 +117,6 @@ private:
 
     void MarkBroken();
 
-    userver::engine::Task Close();
 
     std::vector<std::shared_ptr<RecvMessageQueue>> _received_message_queue_map;
     std::vector<RecvMessageQueue::Producer> _received_message_producer_map;

--- a/src/detail/connection_impl.hpp
+++ b/src/detail/connection_impl.hpp
@@ -73,6 +73,7 @@ public:
     ~ConnectionImpl();
 
     userver::engine::Task Close();
+
 private:
     userver::engine::io::Socket _socket;
     userver::engine::TaskProcessor& bg_task_processor_;
@@ -116,7 +117,6 @@ private:
     void ReceiverLoop();
 
     void MarkBroken();
-
 
     std::vector<std::shared_ptr<RecvMessageQueue>> _received_message_queue_map;
     std::vector<RecvMessageQueue::Producer> _received_message_producer_map;

--- a/src/detail/connection_pool.cpp
+++ b/src/detail/connection_pool.cpp
@@ -12,16 +12,20 @@
 #include <detail/stream_pool.hpp>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <userver/engine/async.hpp>
 #include <userver/engine/deadline.hpp>
 #include <userver/engine/semaphore.hpp>
 #include <userver/engine/task/cancel.hpp>
 #include <userver/engine/task/task_with_result.hpp>
 #include <userver/logging/log.hpp>
+#include <userver/utils/periodic_task.hpp>
 #include <vector>
+#include "cassandra/detail/query_parameters.hpp"
 
 namespace cassandra::detail {
 
+constexpr std::chrono::seconds kMaintainInterval{30};
 constexpr auto kUnlimitedConnecting = std::numeric_limits<std::size_t>::max();
 
 constexpr std::chrono::seconds kConnectingTimeout{2};
@@ -115,6 +119,7 @@ void ConnectionPool::Init(InitMode init_mode) {
             _connect_task_storage.Detach(std::move(task));
         }
         LOG_INFO() << "Pool initialization is ongoing";
+        StartMaintainTask();
         return;
     }
 
@@ -134,6 +139,7 @@ void ConnectionPool::Init(InitMode init_mode) {
             ) << e;
         }
     }
+    StartMaintainTask();
 }
 
 userver::engine::TaskWithResult<bool> ConnectionPool::Connect(
@@ -247,7 +253,7 @@ Connection* ConnectionPool::Pop(userver::engine::Deadline deadline) {
             DropExpiredConnection(connection);
             continue;
         } else if (connection->IsBroken()) {
-            DeleteBrokenConnection(connection);
+            DropBrokenConnection(connection);
             continue;
         }
         return connection;
@@ -291,7 +297,7 @@ void ConnectionPool::DeleteConnection(Connection* connection) {
     delete connection;
 }
 
-void ConnectionPool::DeleteBrokenConnection(Connection* connection) {
+void ConnectionPool::DropBrokenConnection(Connection* connection) {
     LOG_WARNING("Released connection in closed state. Deleting...");
     DeleteConnection(connection);
 }
@@ -335,7 +341,7 @@ void ConnectionPool::Release(Connection* connection) {
     if (connection->IsExpired()) {
         DropExpiredConnection(connection);
     } else if (connection->IsBroken()) {
-        DeleteBrokenConnection(connection);
+        DropBrokenConnection(connection);
     } else {
         LOG_DEBUG("PUSHING CONNECTION");
         Push(connection);
@@ -434,6 +440,88 @@ ResultSet ConnectionPool::BatchExecute(
     return conn->BatchExecute(
         store.ConsistencyLevel(), batch_statements, statement_cmd_ctl
     );
+}
+
+void ConnectionPool::StartMaintainTask() {
+    using Flags = userver::utils::PeriodicTask::Flags;
+    _maintain_task.Start(
+        "maintain_task", {kMaintainInterval, Flags::kStrong}, [this] { Maintain(); }
+    );
+}
+
+
+const Query kPing{"SELECT cluster_name FROM system.local"};
+constexpr auto kIdleDropLimit = 1;
+
+constexpr  StaticQueryParameters<0> kNoParams;
+
+void ConnectionPool::Maintain() {
+
+    if (wait_count_ > 0) {
+        LOG_DEBUG() << "No ping required for connection pool to node: " << _description.contact_point.GetUnderlying();
+        return;
+    }
+
+
+    LOG_DEBUG() << "Ping connection pool " << _description.contact_point.GetUnderlying();
+    auto count = size_semaphore_.UsedApprox();
+    auto drop_left = kIdleDropLimit;
+    auto settings = _settings.Read();
+    while (count > 0) {
+        try {
+            auto deleter = [this](Connection* c) { DeleteConnection(c); };
+            std::unique_ptr<Connection, decltype(deleter)> conn(AcquireImmediate(), deleter);
+            if (!conn) {
+                LOG_DEBUG() << "All connections to `" << _description.contact_point.GetUnderlying() << "` are busy";
+                break;
+            }
+            if (count > settings->min_size && drop_left > 0) {
+                --drop_left;
+                LOG_DEBUG() << "Drop idle connection to `" << _description.contact_point.GetUnderlying() << '`';
+                conn->Close();
+            } else {
+                // Cannot use ConnectionPtr here as we must not use
+                // shared_from_this() here (this would prolong pool's lifetime and
+                // can cause a deadlock on the periodic task). But we can be sure
+                // that `this` outlives the task.
+                const auto releaser = [this](Connection* c) { Release(c); };
+                std::unique_ptr<Connection, decltype(releaser)> capture(conn.release(), releaser);
+                auto prepared_id_ptr = _prepared_statements_map.Get(kPing.GetStatement().GetUnderlying());
+                if(!prepared_id_ptr){
+                    auto prepared_id = capture->Prepare(kPing.GetStatement());
+                    _prepared_statements_map.Put(kPing.GetStatement().GetUnderlying(), prepared_id);
+                    capture->ExecutePrepared(Consistency::kLocalOne, prepared_id, QueryParameters{kNoParams}, std::nullopt);
+                } else {
+                    try{
+                        capture->ExecutePrepared(Consistency::kLocalOne, *prepared_id_ptr, QueryParameters{kNoParams}, std::nullopt);
+                    } catch (const exceptions::Unprepared& e) {
+                        LOG_LIMITED_WARNING("Prepared statements were discatrded on node: {}", _description.contact_point.GetUnderlying());
+                        _prepared_statements_map.Clear();
+                    }
+                }
+            }
+        } catch (const exceptions::RuntimeError& e) {
+            LOG_LIMITED_WARNING() << "Exception while pinging connection to `" << _description.contact_point.GetUnderlying() << "`: " << e;
+        }
+        --count;
+    }
+}
+
+
+Connection* ConnectionPool::AcquireImmediate() {
+    Connection* conn = nullptr;
+    while (_conn_consumer.PopNoblock(conn)) {
+
+        if (conn->IsExpired()) {
+            DropExpiredConnection(conn);
+            continue;
+        } if(conn->IsBroken()){
+            DropBrokenConnection(conn);
+            continue;
+        }
+        return conn;
+    }
+    return nullptr;
 }
 
 }  // namespace cassandra::detail

--- a/src/detail/connection_pool.cpp
+++ b/src/detail/connection_pool.cpp
@@ -45,7 +45,7 @@ ConnectionPool::ConnectionPool(
       _settings(settings),
       _connection_settings(connection_settings),
       _bg_task_processor(bg_task_processor),
-      _prepared_statements_map(100),
+      _prepared_statements_map(8, 256),
       _queue(ConnectionQueue::Create()),
       _conn_consumer(_queue->GetMultiConsumer()),
       _conn_producer(_queue->GetMultiProducer()),
@@ -216,8 +216,6 @@ constexpr std::chrono::seconds kRecentErrorPeriod{15};
 constexpr auto kPendingConnectsMax{1};
 void ConnectionPool::TryCreateConnectionAsync() {
     auto conn_settings = _connection_settings.ReadCopy();
-    // Checking errors is more expensive than incrementing an atomic,
-    // so we check it only if we can start a new connection.
     if (recent_conn_errors_.GetStatsForPeriod(kRecentErrorPeriod, true) <
         conn_settings.recent_errors_threshold) {
         userver::engine::SemaphoreLock size_lock{size_semaphore_, std::try_to_lock};
@@ -317,27 +315,11 @@ void ConnectionPool::DropOutdatedConnection(Connection* connection) {
 ) {
     auto shared_this = shared_from_this();
 
-    // auto config = GetConfigSource().GetSnapshot();
-    // CheckDeadlineIsExpired(config);
     ConnectionPtr connection{Pop(deadline), std::move(shared_this)};
-    // ++stats_.connection.used;
-    // CheckDeadlineIsExpired(config);
-
-    // connection->UpdateDefaultCommandControl();
     return connection;
 }
 
 void ConnectionPool::Release(Connection* connection) {
-    // UASSERT(connection);
-    // using DecGuard =
-    // storages::postgres::SizeGuard<USERVER_NAMESPACE::utils::statistics::RelaxedCounter<uint32_t>>;
-    // DecGuard dg{stats_.connection.used, DecGuard::DontIncrement{}};
-
-    // std::optional<Connection::Statistics> connection_stats{};
-    // Grab stats only if connection is not in transaction
-    // if (!connection->IsInTransaction()) {
-    //     connection_stats.emplace(connection->GetStatsAndReset());
-    // }
     if (connection->IsExpired()) {
         DropExpiredConnection(connection);
     } else if (connection->IsBroken()) {
@@ -346,25 +328,6 @@ void ConnectionPool::Release(Connection* connection) {
         LOG_DEBUG("PUSHING CONNECTION");
         Push(connection);
     }
-    // else {
-    //     // Connection cleanup is done asynchronously while returning control to
-    //     // the user
-    //     close_task_storage_.Detach(USERVER_NAMESPACE::utils::CriticalAsync(
-    //         "clear_conn_after_cancel",
-    //         [this, connection, dec_cnt = std::move(dg)] {
-    //             LOG_LIMITED_WARNING() << "Released connection in busy state.
-    //             Trying to clean up..."; TESTPOINT("pg_cleanup",
-    //             formats::json::Value{}); CleanupConnection(connection);
-    //         }
-    //     ));
-    // }
-
-    // // We want to account the stats AFTER the connection is returned to the pool,
-    // // because the procedure is somewhat heavy and there's no point to prevent the
-    // // connection from being reused
-    // if (connection_stats.has_value()) {
-    //     AccountConnectionStats(std::move(*connection_stats));
-    // }
 }
 
 ResultSet ConnectionPool::Execute(
@@ -449,73 +412,93 @@ void ConnectionPool::StartMaintainTask() {
     );
 }
 
-
 const Query kPing{"SELECT cluster_name FROM system.local"};
 constexpr auto kIdleDropLimit = 1;
 
-constexpr  StaticQueryParameters<0> kNoParams;
+constexpr StaticQueryParameters<0> kNoParams;
 
 void ConnectionPool::Maintain() {
-
     if (wait_count_ > 0) {
-        LOG_DEBUG() << "No ping required for connection pool to node: " << _description.contact_point.GetUnderlying();
+        LOG_DEBUG() << "No ping required for connection pool to node: "
+                    << _description.contact_point.GetUnderlying();
         return;
     }
 
-
-    LOG_DEBUG() << "Ping connection pool " << _description.contact_point.GetUnderlying();
+    LOG_DEBUG() << "Ping connection pool "
+                << _description.contact_point.GetUnderlying();
     auto count = size_semaphore_.UsedApprox();
     auto drop_left = kIdleDropLimit;
     auto settings = _settings.Read();
     while (count > 0) {
         try {
             auto deleter = [this](Connection* c) { DeleteConnection(c); };
-            std::unique_ptr<Connection, decltype(deleter)> conn(AcquireImmediate(), deleter);
+            std::unique_ptr<Connection, decltype(deleter)> conn(
+                AcquireImmediate(), deleter
+            );
             if (!conn) {
-                LOG_DEBUG() << "All connections to `" << _description.contact_point.GetUnderlying() << "` are busy";
+                LOG_DEBUG() << "All connections to `"
+                            << _description.contact_point.GetUnderlying()
+                            << "` are busy";
                 break;
             }
             if (count > settings->min_size && drop_left > 0) {
                 --drop_left;
-                LOG_DEBUG() << "Drop idle connection to `" << _description.contact_point.GetUnderlying() << '`';
+                LOG_DEBUG() << "Drop idle connection to `"
+                            << _description.contact_point.GetUnderlying() << '`';
                 conn->Close();
             } else {
-                // Cannot use ConnectionPtr here as we must not use
-                // shared_from_this() here (this would prolong pool's lifetime and
-                // can cause a deadlock on the periodic task). But we can be sure
-                // that `this` outlives the task.
                 const auto releaser = [this](Connection* c) { Release(c); };
-                std::unique_ptr<Connection, decltype(releaser)> capture(conn.release(), releaser);
-                auto prepared_id_ptr = _prepared_statements_map.Get(kPing.GetStatement().GetUnderlying());
-                if(!prepared_id_ptr){
+                std::unique_ptr<Connection, decltype(releaser)> capture(
+                    conn.release(), releaser
+                );
+                auto prepared_id_ptr =
+                    _prepared_statements_map.Get(kPing.GetStatement().GetUnderlying()
+                    );
+                if (!prepared_id_ptr) {
                     auto prepared_id = capture->Prepare(kPing.GetStatement());
-                    _prepared_statements_map.Put(kPing.GetStatement().GetUnderlying(), prepared_id);
-                    capture->ExecutePrepared(Consistency::kLocalOne, prepared_id, QueryParameters{kNoParams}, std::nullopt);
+                    _prepared_statements_map.Put(
+                        kPing.GetStatement().GetUnderlying(), prepared_id
+                    );
+                    capture->ExecutePrepared(
+                        Consistency::kLocalOne,
+                        prepared_id,
+                        QueryParameters{kNoParams},
+                        std::nullopt
+                    );
                 } else {
-                    try{
-                        capture->ExecutePrepared(Consistency::kLocalOne, *prepared_id_ptr, QueryParameters{kNoParams}, std::nullopt);
+                    try {
+                        capture->ExecutePrepared(
+                            Consistency::kLocalOne,
+                            *prepared_id_ptr,
+                            QueryParameters{kNoParams},
+                            std::nullopt
+                        );
                     } catch (const exceptions::Unprepared& e) {
-                        LOG_LIMITED_WARNING("Prepared statements were discatrded on node: {}", _description.contact_point.GetUnderlying());
-                        _prepared_statements_map.Clear();
+                        LOG_LIMITED_WARNING(
+                            "Prepared statements were discatrded on node: {}",
+                            _description.contact_point.GetUnderlying()
+                        );
+                        _prepared_statements_map.Invalidate();
                     }
                 }
             }
         } catch (const exceptions::RuntimeError& e) {
-            LOG_LIMITED_WARNING() << "Exception while pinging connection to `" << _description.contact_point.GetUnderlying() << "`: " << e;
+            LOG_LIMITED_WARNING()
+                << "Exception while pinging connection to `"
+                << _description.contact_point.GetUnderlying() << "`: " << e;
         }
         --count;
     }
 }
 
-
 Connection* ConnectionPool::AcquireImmediate() {
     Connection* conn = nullptr;
     while (_conn_consumer.PopNoblock(conn)) {
-
         if (conn->IsExpired()) {
             DropExpiredConnection(conn);
             continue;
-        } if(conn->IsBroken()){
+        }
+        if (conn->IsBroken()) {
             DropBrokenConnection(conn);
             continue;
         }

--- a/src/detail/connection_pool.hpp
+++ b/src/detail/connection_pool.hpp
@@ -6,7 +6,7 @@
 #include <cassandra/node_description.hpp>
 #include <cassandra/options.hpp>
 #include <memory>
-#include <userver/cache/lru_map.hpp>
+#include <userver/cache/nway_lru_cache.hpp>
 #include <userver/clients/dns/resolver_fwd.hpp>
 #include <userver/concurrent/background_task_storage.hpp>
 #include <userver/concurrent/queue.hpp>
@@ -73,8 +73,7 @@ private:
     void DropBrokenConnection(Connection* connection);
     void DropExpiredConnection(Connection* connection);
     void DropOutdatedConnection(Connection* connection);
-    
-    
+
     Connection* AcquireImmediate();
 
     [[nodiscard]] userver::engine::TaskWithResult<bool> Connect(
@@ -94,7 +93,7 @@ private:
 
     // prepared statements cache
     // cassandra prepare statements per node and use ShortBytes as ID
-    userver::cache::LruMap<std::string, io::ShortBytes> _prepared_statements_map;
+    userver::cache::NWayLRU<std::string, io::ShortBytes> _prepared_statements_map;
     std::atomic<size_t> wait_count_;
     RecentCounter recent_conn_errors_;
 

--- a/src/detail/connection_pool.hpp
+++ b/src/detail/connection_pool.hpp
@@ -12,6 +12,7 @@
 #include <userver/concurrent/queue.hpp>
 #include <userver/engine/task/task_processor_fwd.hpp>
 #include <userver/rcu/rcu.hpp>
+#include <userver/utils/periodic_task.hpp>
 #include <userver/utils/statistics/fwd.hpp>
 #include <userver/utils/statistics/recentperiod.hpp>
 #include <userver/utils/statistics/relaxed_counter.hpp>
@@ -69,9 +70,12 @@ private:
     Connection* Pop(userver::engine::Deadline);
 
     void DeleteConnection(Connection* connection);
-    void DeleteBrokenConnection(Connection* connection);
+    void DropBrokenConnection(Connection* connection);
     void DropExpiredConnection(Connection* connection);
     void DropOutdatedConnection(Connection* connection);
+    
+    
+    Connection* AcquireImmediate();
 
     [[nodiscard]] userver::engine::TaskWithResult<bool> Connect(
         userver::engine::SemaphoreLock lock, ConnectionSettings&& conn_settings
@@ -106,5 +110,9 @@ private:
     userver::engine::Semaphore connecting_semaphore_;
 
     userver::utils::statistics::MetricsStoragePtr _metrics;
+
+    userver::utils::PeriodicTask _maintain_task;
+    void Maintain();
+    void StartMaintainTask();
 };
 }  // namespace cassandra::detail

--- a/src/io/protocol/response_message.hpp
+++ b/src/io/protocol/response_message.hpp
@@ -18,7 +18,7 @@
 namespace cassandra::io::protocol {
 class ResponseMessage : public Message {
 public:
-    ResponseMessage(FrameHeader&& header) : Message(std::move(header)){};
+    ResponseMessage(FrameHeader&& header) : Message(std::move(header)) {};
 
     static FrameHeader ParseHeader(RawBufferView data) {
         FrameHeader header;
@@ -40,7 +40,7 @@ public:
 
 class ErrorMessage : public ResponseMessage {
 public:
-    ErrorMessage(FrameHeader&& header) : ResponseMessage(std::move(header)){};
+    ErrorMessage(FrameHeader&& header) : ResponseMessage(std::move(header)) {};
 
     ErrorCode GetErrorCode() const { return error_code; }
     String GetErrorMessage() const { return error_message; }
@@ -58,7 +58,7 @@ private:
 
 class ReadyMessage : public ResponseMessage {
 public:
-    ReadyMessage(FrameHeader&& header) : ResponseMessage(std::move(header)){};
+    ReadyMessage(FrameHeader&& header) : ResponseMessage(std::move(header)) {};
 
     // Ready message does not have a body
     void DoParseBody(RawBufferView /*buffer*/) override {}
@@ -67,7 +67,7 @@ public:
 class AuthentificateMessage : public ResponseMessage {
 public:
     AuthentificateMessage(FrameHeader&& header)
-        : ResponseMessage(std::move(header)){};
+        : ResponseMessage(std::move(header)) {};
 
     void DoParseBody(RawBufferView buffer) override {
         auth_challenge = BufferReader<BufferView>{buffer}.Read<String>();
@@ -79,7 +79,7 @@ private:
 
 class SupportMessage : public ResponseMessage {
 public:
-    SupportMessage(FrameHeader&& header) : ResponseMessage(std::move(header)){};
+    SupportMessage(FrameHeader&& header) : ResponseMessage(std::move(header)) {};
 
     StringMultiMap GetOptions() const { return options; }
 
@@ -208,7 +208,7 @@ class ResultMessage : public ResponseMessage {
     }
 
 public:
-    ResultMessage(FrameHeader&& header) : ResponseMessage(std::move(header)){};
+    ResultMessage(FrameHeader&& header) : ResponseMessage(std::move(header)) {};
 
     void DoParseBody(RawBufferView buffer) override {
         auto reader = BufferReader<BufferView>{buffer};

--- a/src/io/protocol/response_message.hpp
+++ b/src/io/protocol/response_message.hpp
@@ -6,10 +6,10 @@
 #include <cassandra/io/protocol/lz4_utils.hpp>
 #include <cassandra/io/protocol/message.hpp>
 #include <cassandra/io/protocol/types.hpp>
+#include <cassandra/result_set.hpp>
 #include <io/protocol/column_option.hpp>
 #include <io/protocol/events/schema_change.hpp>
 #include <memory>
-#include <cassandra/result_set.hpp>
 #include <userver/logging/log.hpp>
 #include <utility>
 #include <variant>


### PR DESCRIPTION
Adding health check task for connection pool

This task will check health of connection in period of 30s, It need to cleanup broken or expired connections and on other hand checks prepared statements are discarded on cassandra node to cleanup prepared statements cache in connection pool